### PR TITLE
feat(feat-stock-product-in-bo): Agregue un input con logica para cambiar el stock ante un doble click

### DIFF
--- a/api/auth/products.ts
+++ b/api/auth/products.ts
@@ -96,3 +96,39 @@ export async function deleteProduct(id: Number) {
             throw error;
     });
 }
+
+export async function updateStockProduct(
+    id: number,
+    request: ProductsInterfaces.updateStockProduct
+) {
+    const url = PathsApi.getFullPath(PathsApi.Endpoints.updateStockProduct + "/" + id);
+    const config = { headers: getAuthHeaders() };
+
+    try {
+        const response = await axios.put(url, request, config);
+        toast.success("Producto actualizado con éxito.");
+        return response;
+    } catch (error) {
+        handleAxiosError(error);
+    }
+}
+
+function getAuthHeaders() {
+    const token = localStorage.getItem("jwt");
+    return {
+        Authorization: token ? `Bearer ${token}` : ""
+    };
+}
+function handleAxiosError(error: any) {
+    if (error.response) {
+        switch (error.response.status) {
+            default:
+                toast.error(error.response.data.message || "Ha ocurrido un error inesperado.");
+        }
+    } else if (error.request) {
+        toast.error("No se recibió respuesta del servidor. Verifica tu conexión.");
+    } else {
+        toast.error(`Error: ${error.message || "Error desconocido"}`);
+    }
+    throw error;
+}

--- a/api/pathsApi.ts
+++ b/api/pathsApi.ts
@@ -7,7 +7,8 @@ export namespace PathsApi {
         user_me: "/v1/auth/me",
         my_products: "/v1/my_products",
         createProduct: "/v1/product",
-        deleteProduct: "/v1/product"
+        deleteProduct: "/v1/product",
+        updateStockProduct: "/v1/product/stock"
     };
 
     export const getFullPath = (path: string) => `${BASE_URL}${path}`;

--- a/components/datatables/cells/EditableStockCell.tsx
+++ b/components/datatables/cells/EditableStockCell.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import React from "react"
+
+type Props = {
+  rowId: number
+  stock: number
+  isEditing: boolean
+  setEditingStockId: (id: number | null) => void
+  onUpdateStock: (id: number, newStock: number) => void
+}
+
+export function EditableStockCell({
+  rowId,
+  stock,
+  isEditing,
+  setEditingStockId,
+  onUpdateStock,
+}: Props) {
+  const [tempStock, setTempStock] = React.useState(stock)
+
+  React.useEffect(() => {
+    setTempStock(stock)
+  }, [stock])
+
+  const handleBlur = () => {
+    setEditingStockId(null)
+    if (tempStock !== stock) {
+      onUpdateStock(rowId, tempStock)
+    }
+  }
+
+  return (
+    <div
+      className="w-24"
+      onDoubleClick={() => setEditingStockId(rowId)}
+    >
+      {isEditing ? (
+        <input
+          type="number"
+          value={tempStock}
+          onChange={(e) => setTempStock(Number(e.target.value))}
+          onBlur={handleBlur}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Escape") {
+              (e.target as HTMLInputElement).blur()
+            }
+          }}
+          className="w-full rounded-md border px-2 py-1 text-sm outline-none"
+          autoFocus
+        />
+      ) : (
+        <span className="cursor-pointer select-none">{stock}</span>
+      )}
+    </div>
+  )
+}

--- a/interfaces/products.ts
+++ b/interfaces/products.ts
@@ -14,4 +14,8 @@ export namespace ProductsInterfaces {
     export interface createProduct extends BaseProduct {
         categoryId: number;
     }
+
+    export interface updateStockProduct {
+        newStock: number
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality to update product stock directly from the data table, along with supporting changes across multiple files. The most significant updates include adding a new API endpoint for stock updates, creating an editable stock cell component, and modifying the data table logic to handle stock updates.

### API Enhancements:
* Added a new function `updateStockProduct` in `api/auth/products.ts` to send stock update requests to the server. This includes error handling and success notifications.
* Introduced a new API path `updateStockProduct` in `api/pathsApi.ts` for stock updates.

### UI Updates:
* Added the `EditableStockCell` component in `components/datatables/cells/EditableStockCell.tsx` to allow inline editing of stock values. It includes double-click activation, input validation, and blur handling for stock updates.
* Updated the `getColumns` function in `components/data-table-products.tsx` to replace the static stock display with the `EditableStockCell` component. This enables dynamic stock updates.

### Data Table Logic Modifications:
* Enhanced the `DataTableProducts` component in `components/data-table-products.tsx` to manage stock editing state and handle stock update logic. This includes maintaining the `editingStockId` state and updating the local data after a successful stock update. [[1]](diffhunk://#diff-840bd22ffb8b53da8238f76c4890211bb71ebbf491f031f2f289871cd57dea48R212-R225) [[2]](diffhunk://#diff-840bd22ffb8b53da8238f76c4890211bb71ebbf491f031f2f289871cd57dea48L206-R241)

### Interface Update:
* Added a new interface `updateStockProduct` in `interfaces/products.ts` to define the structure for stock update requests.