### PR TITLE
feat(feat-put-image): Agregue logica para editar imagen del product

### DIFF
--- a/api/auth/products.ts
+++ b/api/auth/products.ts
@@ -146,6 +146,23 @@ export async function updateNameProduct(
     }
 }
 
+export async function updateImageProduct(
+    id: number,
+    request: ProductsInterfaces.ImageUploadRequest
+) {
+    const url = PathsApi.getFullPath(PathsApi.Endpoints.updateImageProduct + "/" + id);
+    const config = { headers: getAuthHeaders() };
+    const formData = new FormData()
+    formData.append("image", request.image) 
+    try {
+        const response = await axios.put(url, formData, config);
+        toast.success("Producto actualizado con éxito.");
+        return response;
+    } catch (error) {
+        handleAxiosError(error);
+    }
+}
+
 function getAuthHeaders() {
     const token = localStorage.getItem("jwt");
     return {

--- a/api/pathsApi.ts
+++ b/api/pathsApi.ts
@@ -1,3 +1,5 @@
+import { updateImageProduct } from "./auth/products";
+
 export namespace PathsApi {
     const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? ""; 
 
@@ -10,7 +12,8 @@ export namespace PathsApi {
         deleteProduct: "/v1/product",
         updateStockProduct: "/v1/product/stock",
         updateNameProduct: "/v1/product/name",
-        updatePriceProduct: "/v1/product/price"
+        updatePriceProduct: "/v1/product/price",
+        updateImageProduct: "/v1/product/image"
     };
 
     export const getFullPath = (path: string) => `${BASE_URL}${path}`;

--- a/components/data-table-products.tsx
+++ b/components/data-table-products.tsx
@@ -68,13 +68,12 @@ import {
   Tabs,
   TabsContent,
 } from "@/components/ui/tabs"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuSeparator } from "./ui/dropdown-menu"
-import { DropdownMenuItem, DropdownMenuTrigger } from "@radix-ui/react-dropdown-menu"
 import { Tooltip } from "@radix-ui/react-tooltip"
 import { TooltipContent, TooltipTrigger } from "./ui/tooltip"
-import { deleteProduct, updateNameProduct, updatePriceProduct, updateStockProduct } from "@/api/auth/products"
+import { deleteProduct, updateImageProduct, updateNameProduct, updatePriceProduct, updateStockProduct } from "@/api/auth/products"
 import { EditableNumberCell } from "./datatables/cells/EditableStockCell"
 import { EditableStringCell } from "./datatables/cells/EditableStringCell"
+import { EditableFileCell } from "./datatables/cells/EditableFileCell"
 
 export const schema = z.object({
   id: z.number(),
@@ -98,7 +97,10 @@ export function getColumns({
   handleUpdatePrice,
   editingNameId,
   setEditingNameId,
-  handleUpdateName
+  handleUpdateName,
+  editingImageId,
+  setEditingImageId,
+  handleUpdateImage,  
 }: {
   handleDelete: (id: number) => void
   editingStockId: number | null
@@ -109,8 +111,14 @@ export function getColumns({
   handleUpdatePrice: (id: number, newPrice: number) => void,
   editingNameId: number | null
   setEditingNameId: (id: number | null) => void
-  handleUpdateName: (id: number, newName: string) => void
+  handleUpdateName: (id: number, newName: string) => void,
+  editingImageId: number | null
+  setEditingImageId: (id: number | null) => void
+  handleUpdateImage: (id: number, file: File) => void
 }): ColumnDef<z.infer<typeof schema>>[] {
+  const handleUpdateFile = () => {
+    alert("loco")
+  }
   return [
     {
       accessorKey: "name",
@@ -131,9 +139,13 @@ export function getColumns({
       accessorKey: "image",
       header: "Imagen",
       cell: ({ row }) => (
-        <div className="w-20">
-         <img src={row.original.image} alt="" />
-        </div>
+        <EditableFileCell
+          rowId={row.original.id}
+          imageUrl={row.original.image}
+          isEditing={editingImageId === row.original.id}
+          setEditingItemId={setEditingImageId}
+          onUpdateFile={handleUpdateImage}
+        />
       ),
     },
     {
@@ -244,6 +256,7 @@ export function DataTableProducts({
     [data]
   )
 
+  const [editingImageId, setEditingImageId] = React.useState<number | null>(null)
   const [editingStockId, setEditingStockId] = React.useState<number | null>(null)
   const [editingPriceId, setEditingPriceId] = React.useState<number | null>(null)
   const [editingNameId, setEditingNameId] = React.useState<number | null>(null)
@@ -254,6 +267,17 @@ export function DataTableProducts({
       )
     )
     updateStockProduct(id, {newStock});
+  }
+
+
+  const handleUpdateImage = (id: number, file: File) => {
+  const url = URL.createObjectURL(file) // vista previa inmediata
+  setData(prev =>
+    prev.map(product =>
+      product.id === id ? { ...product, image: url } : product
+    )
+  )
+  updateImageProduct(id, {image:file})
   }
 
   const handleUpdatePrice = (id: number, newPrice: number) => {
@@ -293,7 +317,10 @@ export function DataTableProducts({
     handleUpdatePrice,
     editingNameId,
     setEditingNameId,
-    handleUpdateName
+    handleUpdateName,
+    editingImageId,
+    handleUpdateImage,
+    setEditingImageId
   });
 
   const table = useReactTable({

--- a/components/datatables/cells/EditableFileCell.tsx
+++ b/components/datatables/cells/EditableFileCell.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import React from "react"
+
+type Props = {
+  rowId: number
+  imageUrl: string
+  isEditing: boolean
+  setEditingItemId: (id: number | null) => void
+  onUpdateFile: (id: number, file: File) => void
+}
+
+export function EditableFileCell({
+  rowId,
+  imageUrl,
+  isEditing,
+  setEditingItemId,
+  onUpdateFile,
+}: Props) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      onUpdateFile(rowId, file)
+      setEditingItemId(null)
+    }
+  }
+
+  const handleDoubleClick = () => {
+    setEditingItemId(rowId)
+    // Esperar al próximo ciclo de render para asegurarse de que el input esté visible
+    setTimeout(() => {
+      inputRef.current?.click()
+    }, 0)
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      onDoubleClick={handleDoubleClick}
+    >
+      <img
+        src={imageUrl}
+        alt="Imagen"
+        className="h-10 w-10 rounded object-cover border"
+      />
+      {isEditing && (
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="text-sm hidden"
+        />
+      )}
+    </div>
+  )
+}

--- a/interfaces/products.ts
+++ b/interfaces/products.ts
@@ -31,4 +31,8 @@ export namespace ProductsInterfaces {
     export interface updateNameProduct {
         newName: string;
     }
+
+    export type ImageUploadRequest = {
+        image: File
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality to update product images in the application, including backend API integration and frontend UI updates. The most significant changes involve adding a new API endpoint, creating a reusable editable image cell component, and integrating the image update feature into the data table for products.

### Backend API Enhancements:
* Added a new function `updateImageProduct` in `api/auth/products.ts` to handle product image updates via a PUT request, including error handling and success notifications.
* Updated the `PathsApi` namespace in `api/pathsApi.ts` to include a new endpoint, `updateImageProduct`, for managing product image updates.

### Frontend UI Updates:
* Created a new component `EditableFileCell` in `components/datatables/cells/EditableFileCell.tsx` to enable inline editing of product images with a double-click interaction.
* Modified `components/data-table-products.tsx` to:
  - Add state management and handlers for editing product images (`editingImageId`, `handleUpdateImage`). [[1]](diffhunk://#diff-840bd22ffb8b53da8238f76c4890211bb71ebbf491f031f2f289871cd57dea48R259) [[2]](diffhunk://#diff-840bd22ffb8b53da8238f76c4890211bb71ebbf491f031f2f289871cd57dea48R272-R282)
  - Integrate the `EditableFileCell` component into the product table for the image column.

### Type Definitions:
* Added a new type `ImageUploadRequest` in `interfaces/products.ts` to define the structure of the image upload request payload.